### PR TITLE
feat(content): add /articles collection and image blocks for article bodies

### DIFF
--- a/website/scripts/generate-static-pages.js
+++ b/website/scripts/generate-static-pages.js
@@ -13,7 +13,8 @@
  * `public/_redirects`. Emitting standalone shells for them produced "zombie"
  * pages that Google reported as "Discovered – currently not indexed".
  *
- * The homepage ("/") and /guides/* are handled by prerender.js (real content).
+ * The homepage ("/"), /guides/* and /articles/* are handled by prerender.js
+ * (real content).
  */
 
 import fs from 'fs';

--- a/website/scripts/prerender.js
+++ b/website/scripts/prerender.js
@@ -107,7 +107,8 @@ for (const route of prerenderRoutes) {
   };
   const entries = ["/", ...prerenderRoutes].map((r) => {
     const loc = toUrl(r);
-    const priority = r === "/" ? "1.0" : r === "/guides" ? "0.8" : "0.7";
+    const isIndex = r === "/guides" || r === "/articles";
+    const priority = r === "/" ? "1.0" : isIndex ? "0.8" : "0.7";
     const changefreq = r === "/" ? "weekly" : "monthly";
     return `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${today}</lastmod>\n    <changefreq>${changefreq}</changefreq>\n    <priority>${priority}</priority>\n  </url>`;
   });

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -6,10 +6,13 @@ import { lazy, Suspense } from "react";
 import Layout from "@/components/layout/Layout";
 import { ScrollToHash } from "@/components/redesign/RedesignChrome";
 import Index from "./pages/Index"; // homepage stays eager (it's the landing page)
-// Guides are eager so they render during build-time prerender (renderToString does
-// not resolve React.lazy, which would otherwise prerender an empty shell).
+// Guides and articles are eager so they render during build-time prerender
+// (renderToString does not resolve React.lazy, which would otherwise prerender
+// an empty shell).
 import GuidesIndex from "./pages/GuidesIndex";
 import GuideArticle from "./pages/GuideArticle";
+import ArticlesIndex from "./pages/ArticlesIndex";
+import ArticleArticle from "./pages/ArticleArticle";
 
 // Secondary pages are code-split so they don't weigh down the homepage bundle.
 const ContactEnterprise = lazy(() => import("./pages/ContactEnterprise"));
@@ -50,6 +53,11 @@ export default function App() {
             {/* Content / SEO guides */}
             <Route path="/guides" element={<GuidesIndex />} />
             <Route path="/guides/:slug" element={<GuideArticle />} />
+
+            {/* Articles (news / longer-form). Prerendered only once the
+                collection has content — see entry-server.tsx. */}
+            <Route path="/articles" element={<ArticlesIndex />} />
+            <Route path="/articles/:slug" element={<ArticleArticle />} />
 
             {/* The /new preview path is retired post-cutover; send it home. */}
             <Route path="/new/*" element={<Navigate to="/" replace />} />

--- a/website/src/components/ContentBlockView.tsx
+++ b/website/src/components/ContentBlockView.tsx
@@ -1,0 +1,50 @@
+// src/components/ContentBlockView.tsx
+//
+// Renders one block of an article body. Every content collection (guides,
+// articles, ...) renders through this single component, so a block type added
+// to ContentBlock in content/shared.tsx works everywhere at once instead of
+// rendering in one collection and silently disappearing from another.
+//
+// It lives here rather than beside the shapes in content/shared.tsx because a
+// module that exports both components and plain helpers breaks Fast Refresh.
+
+import { ContentBlock, headingId, renderInline } from "@/content/shared";
+
+export default function ContentBlockView({ block }: { block: ContentBlock }) {
+  if ("h2" in block) return <h2 id={headingId(block.h2)}>{block.h2}</h2>;
+  if ("h3" in block) return <h3>{block.h3}</h3>;
+  if ("p" in block) return <p>{renderInline(block.p)}</p>;
+  if ("ul" in block)
+    return (
+      <ul>
+        {block.ul.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ul>
+    );
+  if ("ol" in block)
+    return (
+      <ol>
+        {block.ol.map((item, i) => (
+          <li key={i}>{renderInline(item)}</li>
+        ))}
+      </ol>
+    );
+  if ("callout" in block)
+    return (
+      <div className="callout">
+        {block.callout.title && <h3>{block.callout.title}</h3>}
+        <p>{renderInline(block.callout.body)}</p>
+      </div>
+    );
+  if ("img" in block) {
+    const { src, alt, caption, width, height } = block.img;
+    return (
+      <figure className="content-figure">
+        <img src={src} alt={alt} width={width} height={height} loading="lazy" decoding="async" />
+        {caption && <figcaption>{renderInline(caption)}</figcaption>}
+      </figure>
+    );
+  }
+  return null;
+}

--- a/website/src/content/articles.tsx
+++ b/website/src/content/articles.tsx
@@ -25,13 +25,13 @@ export interface Article {
   category: string;
   readMins: number;
   intro: string;
+  /** ISO date (YYYY-MM-DD) the article first went live; Article datePublished. */
+  publishedAt: string;
+  /** ISO date (YYYY-MM-DD) of the last content review; Article dateModified. */
+  updatedAt: string;
   blocks: ArticleBlock[];
   faqs: ArticleFaq[];
 }
-
-/** Last content review date, used for sitemap lastmod + Article dateModified. */
-export const ARTICLES_UPDATED = "2026-08-04";
-export const ARTICLES_PUBLISHED = "2026-08-04";
 
 export const articles: Article[] = [];
 

--- a/website/src/content/articles.tsx
+++ b/website/src/content/articles.tsx
@@ -1,0 +1,49 @@
+// Single source of truth for the /articles section.
+//
+// Mirrors content/guides.tsx: each article is authored as structured data (no
+// JSX in the content) so the same objects power the rendered article, the
+// Article (+ FAQPage, when it has FAQs) JSON-LD, the articles index cards and
+// the sitemap. Block/FAQ shapes and the inline markdown-link helpers are
+// shared with the guides collection via content/shared.tsx.
+//
+// There is no published content yet — the collection starts empty rather than
+// shipping placeholder copy onto a live client site. The index page renders a
+// real "nothing here yet" state instead of a blank shell, and adding the first
+// article is just pushing an entry into `articles` below.
+
+import { ContentBlock, ContentFaq } from "./shared";
+
+export type ArticleBlock = ContentBlock;
+export type ArticleFaq = ContentFaq;
+
+export interface Article {
+  slug: string;
+  title: string;
+  metaTitle: string;
+  description: string;
+  summary: string;
+  category: string;
+  readMins: number;
+  intro: string;
+  blocks: ArticleBlock[];
+  faqs: ArticleFaq[];
+}
+
+/** Last content review date, used for sitemap lastmod + Article dateModified. */
+export const ARTICLES_UPDATED = "2026-08-04";
+export const ARTICLES_PUBLISHED = "2026-08-04";
+
+export const articles: Article[] = [];
+
+export function getArticle(slug: string | undefined): Article | undefined {
+  return articles.find((a) => a.slug === slug);
+}
+
+/**
+ * Related articles, mirroring guides.tsx's ring layout once there is more
+ * than one article to relate. With zero (or one) articles there is nothing
+ * to link, so this simply returns an empty list.
+ */
+export function getRelatedSlugs(_slug: string): string[] {
+  return [];
+}

--- a/website/src/content/guides.tsx
+++ b/website/src/content/guides.tsx
@@ -2,23 +2,17 @@
 //
 // Each guide is authored as structured data (no JSX in the content) so the same
 // objects power: the rendered article, the Article + FAQPage JSON-LD, the guides
-// index cards, the sitemap and llms.txt entries. Paragraph/list strings may use a
-// tiny markdown-style inline link, [text](/path), which renderInline() turns into
-// a router <Link> (internal) or <a> (external); stripInline() flattens it to plain
-// text for structured data.
+// index cards, the sitemap and llms.txt entries. Block/FAQ shapes and the inline
+// markdown-link helpers live in content/shared.tsx, shared with other content
+// collections (e.g. content/articles.tsx) so there is exactly one definition of
+// what an article body looks like.
 
-import { ReactNode } from "react";
-import { Link } from "react-router-dom";
+import { ContentBlock, ContentFaq, renderInline, stripInline } from "./shared";
 
-export type GuideBlock =
-  | { h2: string }
-  | { h3: string }
-  | { p: string }
-  | { ul: string[] }
-  | { ol: string[] }
-  | { callout: { title?: string; body: string } };
+export type GuideBlock = ContentBlock;
+export type GuideFaq = ContentFaq;
 
-export type GuideFaq = { q: string; a: string };
+export { renderInline, stripInline };
 
 export interface Guide {
   slug: string;
@@ -595,41 +589,4 @@ const relatedSlugsBySlug: Record<string, string[]> = (() => {
 /** The guides to show under "Related guides", newest linking rules applied. */
 export function getRelatedSlugs(slug: string): string[] {
   return relatedSlugsBySlug[slug] ?? [];
-}
-
-const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
-
-/** Turn [text](/path) markdown into router <Link>s (internal) or <a>s (external). */
-export function renderInline(text: string): ReactNode {
-  const out: ReactNode[] = [];
-  let last = 0;
-  let key = 0;
-  let m: RegExpExecArray | null;
-  LINK_RE.lastIndex = 0;
-  while ((m = LINK_RE.exec(text)) !== null) {
-    if (m.index > last) out.push(text.slice(last, m.index));
-    const label = m[1];
-    const href = m[2];
-    if (href.startsWith("/")) {
-      out.push(
-        <Link key={key++} to={href}>
-          {label}
-        </Link>
-      );
-    } else {
-      out.push(
-        <a key={key++} href={href} target="_blank" rel="noopener noreferrer">
-          {label}
-        </a>
-      );
-    }
-    last = LINK_RE.lastIndex;
-  }
-  if (last < text.length) out.push(text.slice(last));
-  return out.length === 1 ? out[0] : out;
-}
-
-/** Flatten [text](/path) markdown to plain text, for JSON-LD / meta. */
-export function stripInline(text: string): string {
-  return text.replace(LINK_RE, "$1");
 }

--- a/website/src/content/shared.tsx
+++ b/website/src/content/shared.tsx
@@ -1,0 +1,103 @@
+// Shared building blocks for content collections (guides, articles, ...).
+//
+// Each collection (see content/guides.tsx, content/articles.tsx) authors its
+// items as structured data using these same block/FAQ shapes, so there is one
+// definition of "what an article body looks like" no matter how many
+// collections the site grows to. Paragraph/list strings may use a tiny
+// markdown-style inline link, [text](/path), which renderInline() turns into
+// a router <Link> (internal) or <a> (external); stripInline() flattens it to
+// plain text for structured data.
+
+import { ReactNode } from "react";
+import { Link } from "react-router-dom";
+
+export type ContentBlock =
+  | { h2: string }
+  | { h3: string }
+  | { p: string }
+  | { ul: string[] }
+  | { ol: string[] }
+  | { callout: { title?: string; body: string } }
+  | { img: ContentImage };
+
+/**
+ * An image inside an article body.
+ *
+ * `alt` is required, not optional: a decorative image has no place in the
+ * middle of an article, and search engines read the alt text as content.
+ * `width`/`height` are the image's intrinsic pixel size — supplying them lets
+ * the browser reserve the space before the file loads, so an image part-way
+ * down the page cannot shove the text around it (cumulative layout shift).
+ */
+export type ContentImage = {
+  src: string;
+  alt: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+};
+
+export type ContentFaq = { q: string; a: string };
+
+const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+
+/** Turn [text](/path) markdown into router <Link>s (internal) or <a>s (external). */
+export function renderInline(text: string): ReactNode {
+  const out: ReactNode[] = [];
+  let last = 0;
+  let key = 0;
+  let m: RegExpExecArray | null;
+  LINK_RE.lastIndex = 0;
+  while ((m = LINK_RE.exec(text)) !== null) {
+    if (m.index > last) out.push(text.slice(last, m.index));
+    const label = m[1];
+    const href = m[2];
+    if (href.startsWith("/")) {
+      out.push(
+        <Link key={key++} to={href}>
+          {label}
+        </Link>
+      );
+    } else {
+      out.push(
+        <a key={key++} href={href} target="_blank" rel="noopener noreferrer">
+          {label}
+        </a>
+      );
+    }
+    last = LINK_RE.lastIndex;
+  }
+  if (last < text.length) out.push(text.slice(last));
+  return out.length === 1 ? out[0] : out;
+}
+
+/** Flatten [text](/path) markdown to plain text, for JSON-LD / meta. */
+export function stripInline(text: string): string {
+  return text.replace(LINK_RE, "$1");
+}
+
+/** Slug for an h2, so the on-this-page nav can link to it. */
+export function headingId(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+/**
+ * Every body image, in document order. An article may carry as many as it likes.
+ * Article JSON-LD takes `image` as an array, and Google asks for several images
+ * where they exist, so all of them are offered rather than only the first.
+ */
+export function imageSrcs(blocks: ContentBlock[]): string[] {
+  return blocks.flatMap((b) => ("img" in b ? [b.img.src] : []));
+}
+
+/**
+ * Structured data needs an absolute image URL, but body images are authored as
+ * site-root paths ("/assets/x.webp"). Leave an already-absolute URL alone.
+ */
+export function absoluteImage(src: string, site: string): string {
+  return /^https?:\/\//i.test(src) ? src : `${site}${src}`;
+}

--- a/website/src/entry-server.tsx
+++ b/website/src/entry-server.tsx
@@ -4,6 +4,7 @@ import { StaticRouter } from "react-router-dom/server";
 import { HelmetProvider } from "react-helmet-async";
 import App from "./App";
 import { guides } from "./content/guides";
+import { articles } from "./content/articles";
 
 /**
  * Render a route to static HTML for build-time prerendering.
@@ -31,8 +32,19 @@ export function render(url: string): { html: string; head: string; headFull: str
   return { html, head, headFull };
 }
 
-/** Routes (besides "/") to prerender into their own dist/<route>/index.html. */
+/**
+ * Routes (besides "/") to prerender into their own dist/<route>/index.html.
+ * This list also drives sitemap.xml (see scripts/prerender.js), so a route only
+ * belongs here if it is a real, indexable page.
+ *
+ * The articles index is deliberately withheld while the collection is empty:
+ * prerendering it would put a "nothing here yet" page in the sitemap, which is
+ * exactly the thin-content shell that got the old anchor routes reported as
+ * "Discovered – currently not indexed". Publishing the first article brings the
+ * index and that article in together.
+ */
 export const prerenderRoutes: string[] = [
   "/guides",
   ...guides.map((g) => `/guides/${g.slug}`),
+  ...(articles.length > 0 ? ["/articles", ...articles.map((a) => `/articles/${a.slug}`)] : []),
 ];

--- a/website/src/pages/ArticleArticle.tsx
+++ b/website/src/pages/ArticleArticle.tsx
@@ -2,7 +2,7 @@
 import { Link, Navigate, useParams } from "react-router-dom";
 import Seo from "@/components/Seo";
 import { PageShell } from "@/components/redesign/RedesignChrome";
-import { ARTICLES_PUBLISHED, ARTICLES_UPDATED, getArticle, getRelatedSlugs } from "@/content/articles";
+import { getArticle, getRelatedSlugs } from "@/content/articles";
 import ContentBlockView from "@/components/ContentBlockView";
 import { absoluteImage, headingId, imageSrcs, stripInline } from "@/content/shared";
 import "@/styles/home.css";
@@ -36,8 +36,8 @@ export default function ArticleArticle() {
     headline: article.title,
     description: stripInline(article.description),
     inLanguage: "en-ZA",
-    datePublished: ARTICLES_PUBLISHED,
-    dateModified: ARTICLES_UPDATED,
+    datePublished: article.publishedAt,
+    dateModified: article.updatedAt,
     author: { "@type": "Organization", name: "All Done Sites", url: SITE },
     publisher: {
       "@type": "Organization",
@@ -71,7 +71,7 @@ export default function ArticleArticle() {
         <span className="guide-meta">
           <span className="mono">{article.readMins} min read</span>
           <span aria-hidden="true"> · </span>
-          <span className="mono">Updated {ARTICLES_UPDATED}</span>
+          <span className="mono">Updated {article.updatedAt}</span>
         </span>
       }
     >

--- a/website/src/pages/ArticleArticle.tsx
+++ b/website/src/pages/ArticleArticle.tsx
@@ -1,49 +1,43 @@
-// src/pages/GuideArticle.tsx
+// src/pages/ArticleArticle.tsx
 import { Link, Navigate, useParams } from "react-router-dom";
 import Seo from "@/components/Seo";
 import { PageShell } from "@/components/redesign/RedesignChrome";
-import {
-  GUIDES_PUBLISHED,
-  GUIDES_UPDATED,
-  getGuide,
-  getRelatedSlugs,
-  stripInline,
-} from "@/content/guides";
+import { ARTICLES_PUBLISHED, ARTICLES_UPDATED, getArticle, getRelatedSlugs } from "@/content/articles";
 import ContentBlockView from "@/components/ContentBlockView";
-import { absoluteImage, headingId, imageSrcs } from "@/content/shared";
+import { absoluteImage, headingId, imageSrcs, stripInline } from "@/content/shared";
 import "@/styles/home.css";
 
 const SITE = "https://alldonesites.com";
 const OG_IMAGE = `${SITE}/og1200x630_v2.jpg`;
 
-export default function GuideArticle() {
+export default function ArticleArticle() {
   const { slug } = useParams();
-  const guide = getGuide(slug);
+  const article = getArticle(slug);
 
-  // Unknown slug: send back to the guides index (valid slugs are prerendered).
-  if (!guide) return <Navigate to="/guides/" replace />;
+  // Unknown slug: send back to the articles index (valid slugs are prerendered).
+  if (!article) return <Navigate to="/articles/" replace />;
 
   // Trailing slash to match the URL Cloudflare Pages actually serves
   // (it 308-redirects the no-slash form to the directory form).
-  const url = `${SITE}/guides/${guide.slug}/`;
-  const toc = guide.blocks.filter((b): b is { h2: string } => "h2" in b).map((b) => b.h2);
-  const related = getRelatedSlugs(guide.slug)
-    .map((s) => getGuide(s))
-    .filter(Boolean) as NonNullable<ReturnType<typeof getGuide>>[];
+  const url = `${SITE}/articles/${article.slug}/`;
+  const toc = article.blocks.filter((b): b is { h2: string } => "h2" in b).map((b) => b.h2);
+  const related = getRelatedSlugs(article.slug)
+    .map((s) => getArticle(s))
+    .filter(Boolean) as NonNullable<ReturnType<typeof getArticle>>[];
 
-  // Prefer the guide's own images for structured data (all of them, in order);
-  // fall back to the site-wide OG image when the guide is text-only.
-  const bodyImages = imageSrcs(guide.blocks).map((s) => absoluteImage(s, SITE));
+  // Prefer the article's own images for structured data (all of them, in order);
+  // fall back to the site-wide OG image when the article is text-only.
+  const bodyImages = imageSrcs(article.blocks).map((s) => absoluteImage(s, SITE));
   const schemaImage = bodyImages.length > 0 ? bodyImages : OG_IMAGE;
 
   const articleSchema = {
     "@context": "https://schema.org",
     "@type": "Article",
-    headline: guide.title,
-    description: stripInline(guide.description),
+    headline: article.title,
+    description: stripInline(article.description),
     inLanguage: "en-ZA",
-    datePublished: GUIDES_PUBLISHED,
-    dateModified: GUIDES_UPDATED,
+    datePublished: ARTICLES_PUBLISHED,
+    dateModified: ARTICLES_UPDATED,
     author: { "@type": "Organization", name: "All Done Sites", url: SITE },
     publisher: {
       "@type": "Organization",
@@ -55,39 +49,43 @@ export default function GuideArticle() {
     image: schemaImage,
   };
 
-  const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: guide.faqs.map((f) => ({
-      "@type": "Question",
-      name: f.q,
-      acceptedAnswer: { "@type": "Answer", text: stripInline(f.a) },
-    })),
-  };
+  // Only emit FAQPage structured data when the article actually has FAQs.
+  const faqSchema =
+    article.faqs.length > 0
+      ? {
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: article.faqs.map((f) => ({
+            "@type": "Question",
+            name: f.q,
+            acceptedAnswer: { "@type": "Answer", text: stripInline(f.a) },
+          })),
+        }
+      : undefined;
 
   return (
     <PageShell
-      eyebrow={guide.category}
-      title={guide.title}
+      eyebrow={article.category}
+      title={article.title}
       sub={
         <span className="guide-meta">
-          <span className="mono">{guide.readMins} min read</span>
+          <span className="mono">{article.readMins} min read</span>
           <span aria-hidden="true"> · </span>
-          <span className="mono">Updated {GUIDES_UPDATED}</span>
+          <span className="mono">Updated {ARTICLES_UPDATED}</span>
         </span>
       }
     >
       <Seo
-        title={guide.metaTitle}
-        description={guide.description}
+        title={article.metaTitle}
+        description={article.description}
         canonical={url}
         image={OG_IMAGE}
-        jsonLd={[articleSchema, faqSchema]}
+        jsonLd={faqSchema ? [articleSchema, faqSchema] : articleSchema}
       />
 
       <div className="guide-layout">
         <article className="legal guide-body">
-          <p className="intro">{guide.intro}</p>
+          <p className="intro">{article.intro}</p>
 
           {toc.length > 2 && (
             <nav className="toc" aria-label="On this page">
@@ -102,14 +100,14 @@ export default function GuideArticle() {
             </nav>
           )}
 
-          {guide.blocks.map((block, i) => (
+          {article.blocks.map((block, i) => (
             <ContentBlockView key={i} block={block} />
           ))}
 
-          {guide.faqs.length > 0 && (
+          {article.faqs.length > 0 && (
             <section className="guide-faqs" aria-label="Frequently asked questions">
               <h2 id="faqs">Frequently asked questions</h2>
-              {guide.faqs.map((f) => (
+              {article.faqs.map((f) => (
                 <div className="qa" key={f.q}>
                   <h3>{f.q}</h3>
                   <p>{f.a}</p>
@@ -135,11 +133,11 @@ export default function GuideArticle() {
           </aside>
 
           {related.length > 0 && (
-            <section className="guide-related" aria-label="Related guides">
-              <h2>Related guides</h2>
+            <section className="guide-related" aria-label="Related articles">
+              <h2>Related articles</h2>
               <div className="guide-related-grid">
                 {related.map((r) => (
-                  <Link to={`/guides/${r.slug}/`} className="guide-related-card" key={r.slug}>
+                  <Link to={`/articles/${r.slug}/`} className="guide-related-card" key={r.slug}>
                     <span className="eyebrow kicker">{r.category}</span>
                     <span className="grtitle">{r.title}</span>
                   </Link>
@@ -149,7 +147,7 @@ export default function GuideArticle() {
           )}
 
           <p className="guide-back">
-            <Link to="/guides/">← All guides</Link>
+            <Link to="/articles/">← All articles</Link>
           </p>
         </article>
       </div>

--- a/website/src/pages/ArticlesIndex.tsx
+++ b/website/src/pages/ArticlesIndex.tsx
@@ -1,0 +1,62 @@
+// src/pages/ArticlesIndex.tsx
+import { Link } from "react-router-dom";
+import Seo from "@/components/Seo";
+import { PageShell } from "@/components/redesign/RedesignChrome";
+import { articles } from "@/content/articles";
+import "@/styles/home.css";
+
+const SITE = "https://alldonesites.com";
+const OG_IMAGE = `${SITE}/og1200x630_v2.jpg`;
+
+export default function ArticlesIndex() {
+  const itemListSchema = {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: "All Done Sites articles",
+    itemListElement: articles.map((a, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      url: `${SITE}/articles/${a.slug}/`,
+      name: a.title,
+    })),
+  };
+
+  return (
+    <PageShell
+      eyebrow="Articles"
+      title="Articles from All Done Sites"
+      sub="News, updates and longer-form writing from the All Done Sites team."
+    >
+      <Seo
+        title="Articles | All Done Sites"
+        description="News, updates and longer-form writing from the All Done Sites team."
+        canonical={`${SITE}/articles/`}
+        image={OG_IMAGE}
+        jsonLd={articles.length > 0 ? itemListSchema : undefined}
+      />
+
+      {articles.length === 0 ? (
+        <div className="legal">
+          <p>
+            We have not published any articles yet. In the meantime, our{" "}
+            <Link to="/guides/">guides</Link> answer the questions small business owners most often
+            ask about getting a website in South Africa.
+          </p>
+        </div>
+      ) : (
+        <div className="guidegrid">
+          {articles.map((a) => (
+            <Link to={`/articles/${a.slug}/`} className="guidecard" key={a.slug}>
+              <span className="eyebrow kicker">{a.category}</span>
+              <h2>{a.title}</h2>
+              <p>{a.summary}</p>
+              <span className="guidecard-meta mono">
+                {a.readMins} min read <span className="arrow" aria-hidden="true">→</span>
+              </span>
+            </Link>
+          ))}
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/website/src/styles/home.css
+++ b/website/src/styles/home.css
@@ -383,6 +383,12 @@ html { scroll-behavior: smooth; }
 .adsx .guide-body h2 { margin-top: 34px; scroll-margin-top: 90px; }
 .adsx .guide-body h3 { font-size: 16px; }
 
+/* In-article images. height:auto keeps the aspect ratio when the intrinsic
+   width/height attributes are set (they reserve the space, preventing shift). */
+.adsx .content-figure { margin: 26px 0; }
+.adsx .content-figure img { display: block; width: 100%; height: auto; border-radius: 14px; border: 1px solid var(--ads-line); box-shadow: var(--ads-sh); }
+.adsx .content-figure figcaption { margin-top: 10px; font-size: 13px; line-height: 1.5; color: var(--ads-bd); text-align: center; }
+
 /* FAQs */
 .adsx .guide-faqs { margin-top: 40px; border-top: 1px solid var(--ads-line); padding-top: 8px; }
 .adsx .guide-faqs .qa { margin-top: 20px; }


### PR DESCRIPTION
Adds two things the content pipeline was blocked on: images inside article bodies, and the `/articles` collection.

## Images

`ContentBlock` had no image variant, so an article body could not contain a picture at all — a generated article could ask for one and the site would silently drop it. Adds:

```ts
| { img: { src: string; alt: string; caption?: string; width?: number; height?: number } }
```

An article may carry as many images as it likes, and each one is independent — one figure may be sized and captioned while the next is neither.

- **`alt` is required, not optional.** An image in the middle of an article is content, not decoration, and crawlers read the alt text.
- **`width`/`height` are the intrinsic pixel size.** Supplying them lets the browser reserve the space before the file loads, so a mid-page image cannot shove the surrounding text around as it arrives.
- **Body images become the `Article` JSON-LD `image`**, in document order and as an array — that is what schema.org takes, and Google asks for several images where they exist. Site-root paths are made absolute; an already-absolute URL is left alone. A text-only article still falls back to the single site OG image, so every existing guide is unaffected.

### The renderer was duplicated

`GuideArticle` and `ArticleArticle` each carried a byte-for-byte copy of the block renderer. That is exactly how a new block type ends up rendering in one collection and silently vanishing from the other. It now lives once in `components/ContentBlockView`, so guides and articles gain block types together.

It sits in `components/` rather than beside the shapes in `content/shared` because a module that exports both components and plain helpers breaks Fast Refresh (and, as the linter puts it, warns about it).

## Articles

Wires `/articles` and `/articles/:slug`. Both are eager-imported for the same reason guides are: `renderToString` does not resolve `React.lazy`, so a lazy route prerenders an empty shell.

**The collection ships empty**, and the articles index is deliberately withheld from `prerenderRoutes` — and therefore from `sitemap.xml`, which is derived from it — until there is content. Prerendering it would publish a "nothing here yet" page into the sitemap, which is the same thin-content shell that got the old anchor routes reported *"Discovered – currently not indexed"* (see the comments in `public/_redirects`). Publishing the first article brings the index and that article in together.

The cost of that choice: a direct hit to `/articles/` 404s until the first article exists. Nothing links there, so nothing regresses.

## Verification

- `tsc --noEmit` clean; `eslint` clean with **no warnings**.
- **A full production build of this branch is byte-identical to a build of `origin/main`** across all 16 prerendered pages and `sitemap.xml`, once content-hashed asset names and `lastmod` are normalised. The live site's output is provably unchanged, and the new code is inert until content uses it.
- Because none of the new code runs while the collection is empty, it was exercised by temporarily seeding articles with three images in one body, mixed captions and dimensions, a relative and an absolute `src`, and a separate text-only article. That proved ordering, per-image caption and sizing, the JSON-LD image array, and the OG fallback all reach the raw prerendered HTML. The seed content was then removed.

## Not included

- `public/llms.txt` has no Articles section — it is hand-maintained and there is nothing to list yet.
- Per-article OG images are a separate, smaller job (head metadata, not a body block).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an articles index with responsive article cards and helpful empty-state guidance.
  - Added article detail pages with metadata, table of contents, FAQs, related articles, and navigation.
  - Added support for headings, lists, callouts, images, captions, and inline links in content.
- **Improvements**
  - Guides now use consistent content rendering and image handling.
  - Guides and articles support prerendering, sitemap inclusion, and improved route priorities.
  - Added responsive styling for in-article images and captions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->