### PR TITLE
fix(guides): collapse the in-article nav and stop it colliding with the header

### DIFF
--- a/website/src/components/ArticleNav.tsx
+++ b/website/src/components/ArticleNav.tsx
@@ -1,0 +1,44 @@
+// src/components/ArticleNav.tsx
+import { useRef } from "react";
+import { headingId } from "@/content/shared";
+
+interface ArticleNavProps {
+  toc: string[];
+}
+
+// Collapsed-by-default table of contents for long-form guides/articles. Uses a
+// native <details>/<summary> disclosure so it renders correctly in the static
+// prerendered HTML with no JavaScript (search crawlers and no-JS readers see it
+// closed) and is keyboard/screen-reader accessible out of the box. The only bit
+// of JS enhancement is closing the disclosure after a link is clicked, so the
+// reader lands on their section with the menu out of the way; without JS the
+// links still navigate, they just leave the disclosure open.
+export default function ArticleNav({ toc }: ArticleNavProps) {
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  if (toc.length <= 2) return null;
+
+  return (
+    <nav className="toc" aria-label="Table of contents">
+      <details ref={detailsRef}>
+        <summary>Jump to a section</summary>
+        <ol
+          onClick={(event) => {
+            // Only a real link click should collapse the menu. The list carries
+            // enough padding that a stray tap on its background would otherwise
+            // close the disclosure without navigating anywhere, which reads as
+            // the menu dismissing itself.
+            if (!(event.target as HTMLElement).closest("a")) return;
+            if (detailsRef.current) detailsRef.current.open = false;
+          }}
+        >
+          {toc.map((h) => (
+            <li key={h}>
+              <a href={`#${headingId(h)}`}>{h}</a>
+            </li>
+          ))}
+        </ol>
+      </details>
+    </nav>
+  );
+}

--- a/website/src/pages/ArticleArticle.tsx
+++ b/website/src/pages/ArticleArticle.tsx
@@ -4,7 +4,8 @@ import Seo from "@/components/Seo";
 import { PageShell } from "@/components/redesign/RedesignChrome";
 import { getArticle, getRelatedSlugs } from "@/content/articles";
 import ContentBlockView from "@/components/ContentBlockView";
-import { absoluteImage, headingId, imageSrcs, stripInline } from "@/content/shared";
+import ArticleNav from "@/components/ArticleNav";
+import { absoluteImage, imageSrcs, stripInline } from "@/content/shared";
 import "@/styles/home.css";
 
 const SITE = "https://alldonesites.com";
@@ -87,18 +88,7 @@ export default function ArticleArticle() {
         <article className="legal guide-body">
           <p className="intro">{article.intro}</p>
 
-          {toc.length > 2 && (
-            <nav className="toc" aria-label="On this page">
-              <h3>On this page</h3>
-              <ol>
-                {toc.map((h) => (
-                  <li key={h}>
-                    <a href={`#${headingId(h)}`}>{h}</a>
-                  </li>
-                ))}
-              </ol>
-            </nav>
-          )}
+          <ArticleNav toc={toc} />
 
           {article.blocks.map((block, i) => (
             <ContentBlockView key={i} block={block} />

--- a/website/src/pages/GuideArticle.tsx
+++ b/website/src/pages/GuideArticle.tsx
@@ -10,7 +10,8 @@ import {
   stripInline,
 } from "@/content/guides";
 import ContentBlockView from "@/components/ContentBlockView";
-import { absoluteImage, headingId, imageSrcs } from "@/content/shared";
+import ArticleNav from "@/components/ArticleNav";
+import { absoluteImage, imageSrcs } from "@/content/shared";
 import "@/styles/home.css";
 
 const SITE = "https://alldonesites.com";
@@ -89,18 +90,7 @@ export default function GuideArticle() {
         <article className="legal guide-body">
           <p className="intro">{guide.intro}</p>
 
-          {toc.length > 2 && (
-            <nav className="toc" aria-label="On this page">
-              <h3>On this page</h3>
-              <ol>
-                {toc.map((h) => (
-                  <li key={h}>
-                    <a href={`#${headingId(h)}`}>{h}</a>
-                  </li>
-                ))}
-              </ol>
-            </nav>
-          )}
+          <ArticleNav toc={toc} />
 
           {guide.blocks.map((block, i) => (
             <ContentBlockView key={i} block={block} />

--- a/website/src/styles/home.css
+++ b/website/src/styles/home.css
@@ -12,9 +12,13 @@
      section" bar sticks directly beneath it. Both are declared here because
      three separate rules depend on them -- the article nav's `top`, its open
      list's max-height, and the scroll-margin-top that keeps a jumped-to heading
-     clear of both. Hardcoding them separately is how those values drift apart. */
+     clear of both. Hardcoding them separately is how those values drift apart.
+     --ads-tocbar is the summary bar's measured rendered height (padding +
+     line-height), not a guess -- the scroll-margin calc depends on it matching
+     reality, so re-measure and update it if the summary's font-size or padding
+     ever changes. */
   --ads-navh: 65px;
-  --ads-tocbar: 46px;
+  --ads-tocbar: 52px;
   --ads-bg: #FBFCFD;
   --ads-surface: #FFFFFF;
   --ads-soft: #F4F7FA;
@@ -316,8 +320,8 @@ html { scroll-behavior: smooth; }
    makes EVERY nav in the page sticky at top:0). Without this the article nav
    sticks to the same 0 offset as the site header and the two overlap. It sticks
    just below the header instead, on a lower z-index so the header always wins. */
-.adsx .toc { position: sticky; top: var(--ads-navh); z-index: 40; border: 1px solid var(--ads-line); background: var(--ads-surface); border-radius: 16px; margin: 22px 0 30px; box-shadow: var(--ads-sh); overflow: hidden; }
-.adsx .toc summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; list-style: none; cursor: pointer; padding: 14px 22px; min-height: var(--ads-tocbar); box-sizing: border-box; font-family: var(--ads-disp); font-weight: 600; font-size: 14px; color: var(--ads-tx); user-select: none; background: var(--ads-surface); }
+.adsx .toc { position: sticky; top: var(--ads-navh); z-index: 40; border: 1px solid var(--ads-line); background: var(--ads-surface); border-radius: 16px; margin: 22px 0 30px; box-shadow: var(--ads-sh); overflow: hidden; backdrop-filter: none; }
+.adsx .toc summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; list-style: none; cursor: pointer; padding: 14px 22px; min-height: var(--ads-tocbar); box-sizing: border-box; font-family: var(--ads-disp); font-weight: 600; font-size: 14px; color: var(--ads-tx); user-select: none; background: var(--ads-surface); overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 .adsx .toc summary::-webkit-details-marker { display: none; }
 .adsx .toc summary::after { content: "+"; flex: none; font-size: 18px; line-height: 1; color: var(--ads-acd); }
 .adsx .toc summary:hover { background: var(--ads-soft); }
@@ -326,7 +330,7 @@ html { scroll-behavior: smooth; }
 /* ⚠ The open list must never fill the viewport -- that was the original bug. It
    is capped to what is left below the two sticky bars and scrolls internally, so
    an article with many headings opens a scrollable menu rather than a wall. */
-.adsx .toc ol { margin: 0; padding: 16px 22px 18px 42px; display: flex; flex-direction: column; gap: 5px; max-height: calc(100vh - var(--ads-navh) - var(--ads-tocbar) - 40px); overflow-y: auto; overscroll-behavior: contain; background: var(--ads-surface); }
+.adsx .toc ol { margin: 0; padding: 16px 22px 18px 42px; display: flex; flex-direction: column; gap: 5px; max-height: calc(100dvh - var(--ads-navh) - var(--ads-tocbar) - 40px); overflow-y: auto; overscroll-behavior: contain; background: var(--ads-surface); }
 .adsx .toc a { font-size: 13px; color: var(--ads-acd); text-decoration: none; }
 .adsx .toc a:hover { text-decoration: underline; }
 

--- a/website/src/styles/home.css
+++ b/website/src/styles/home.css
@@ -7,6 +7,14 @@
    ============================================================================ */
 
 :root {
+  /* Heights of the two stacked sticky bars on an article page. The site nav is
+     .navinner's 64px plus its 1px bottom border; the in-article "Jump to a
+     section" bar sticks directly beneath it. Both are declared here because
+     three separate rules depend on them -- the article nav's `top`, its open
+     list's max-height, and the scroll-margin-top that keeps a jumped-to heading
+     clear of both. Hardcoding them separately is how those values drift apart. */
+  --ads-navh: 65px;
+  --ads-tocbar: 46px;
   --ads-bg: #FBFCFD;
   --ads-surface: #FFFFFF;
   --ads-soft: #F4F7FA;
@@ -304,9 +312,21 @@ html { scroll-behavior: smooth; }
 .adsx .callout { border: 1px solid var(--ads-line); background: linear-gradient(160deg, #F3FAFE, #fff); border-radius: 16px; padding: 20px 22px; margin: 22px 0; box-shadow: var(--ads-sh); }
 .adsx .callout h3 { margin-bottom: 8px; font-size: 15px; }
 .adsx .callout p, .adsx .callout li { font-size: 13.5px; color: var(--ads-bd); }
-.adsx .toc { border: 1px solid var(--ads-line); background: var(--ads-surface); border-radius: 16px; padding: 18px 22px; margin: 22px 0 30px; box-shadow: var(--ads-sh); }
-.adsx .toc h3 { font-family: var(--ads-disp); font-size: 14px; margin-bottom: 10px; color: var(--ads-tx); }
-.adsx .toc ol { margin: 0 0 0 20px; display: flex; flex-direction: column; gap: 5px; }
+/* ⚠ `position` and `z-index` are set explicitly to override `.adsx nav` (which
+   makes EVERY nav in the page sticky at top:0). Without this the article nav
+   sticks to the same 0 offset as the site header and the two overlap. It sticks
+   just below the header instead, on a lower z-index so the header always wins. */
+.adsx .toc { position: sticky; top: var(--ads-navh); z-index: 40; border: 1px solid var(--ads-line); background: var(--ads-surface); border-radius: 16px; margin: 22px 0 30px; box-shadow: var(--ads-sh); overflow: hidden; }
+.adsx .toc summary { display: flex; align-items: center; justify-content: space-between; gap: 10px; list-style: none; cursor: pointer; padding: 14px 22px; min-height: var(--ads-tocbar); box-sizing: border-box; font-family: var(--ads-disp); font-weight: 600; font-size: 14px; color: var(--ads-tx); user-select: none; background: var(--ads-surface); }
+.adsx .toc summary::-webkit-details-marker { display: none; }
+.adsx .toc summary::after { content: "+"; flex: none; font-size: 18px; line-height: 1; color: var(--ads-acd); }
+.adsx .toc summary:hover { background: var(--ads-soft); }
+.adsx .toc details[open] summary::after { content: "\2212"; }
+.adsx .toc details[open] summary { border-bottom: 1px solid var(--ads-line); }
+/* ⚠ The open list must never fill the viewport -- that was the original bug. It
+   is capped to what is left below the two sticky bars and scrolls internally, so
+   an article with many headings opens a scrollable menu rather than a wall. */
+.adsx .toc ol { margin: 0; padding: 16px 22px 18px 42px; display: flex; flex-direction: column; gap: 5px; max-height: calc(100vh - var(--ads-navh) - var(--ads-tocbar) - 40px); overflow-y: auto; overscroll-behavior: contain; background: var(--ads-surface); }
 .adsx .toc a { font-size: 13px; color: var(--ads-acd); text-decoration: none; }
 .adsx .toc a:hover { text-decoration: underline; }
 
@@ -380,8 +400,11 @@ html { scroll-behavior: smooth; }
 .adsx .guide-meta { display: inline-flex; align-items: center; gap: 2px; }
 .adsx .guide-body { max-width: 760px; }
 .adsx .guide-body .intro { font-size: 17px; line-height: 1.6; color: var(--ads-tx); margin-bottom: 6px; }
-.adsx .guide-body h2 { margin-top: 34px; scroll-margin-top: 90px; }
-.adsx .guide-body h3 { font-size: 16px; }
+/* Jumped-to headings must clear BOTH sticky bars (site nav + article nav), or
+   the heading you asked for lands underneath them. Derived from the same two
+   vars the bars themselves use, plus breathing room. */
+.adsx .guide-body h2 { margin-top: 34px; scroll-margin-top: calc(var(--ads-navh) + var(--ads-tocbar) + 20px); }
+.adsx .guide-body h3 { font-size: 16px; scroll-margin-top: calc(var(--ads-navh) + var(--ads-tocbar) + 20px); }
 
 /* In-article images. height:auto keeps the aspect ratio when the intrinsic
    width/height attributes are set (they reserve the space, preventing shift). */


### PR DESCRIPTION
## Problem

The in-article table of contents rendered as an always-open list of every H2. On a long guide that fills most of a phone screen before the reader reaches any prose.

It was also **sticky at `top: 0`** — not deliberately. `.adsx nav` (home.css:61) sets `position: sticky; top: 0; z-index: 50` on *every* `<nav>` in the page, and the table of contents is a `<nav>`. It has therefore been competing with the site header for the same strip all along.

And `scroll-margin-top` on `.guide-body h2` was `90px`, which only accounts for the header. A heading jumped to from the menu landed underneath the second bar.

## Change

- Collapsed-by-default `<details>`/`<summary>` disclosure labelled **"Jump to a section"**. Native element, so it renders correctly in the prerendered HTML with no JavaScript and is keyboard/screen-reader accessible as-is. The only scripted behaviour is closing it after a link is clicked, and that degrades safely.
- The bar now sticks **directly beneath** the header, on a lower `z-index` so the header always wins.
- Jumped-to headings clear **both** sticky bars.
- The open list is capped to the space left below both bars and scrolls internally, so a guide with many headings no longer opens a full-screen menu — which was the original complaint.
- Guides and articles share one `ArticleNav` component instead of each carrying its own copy of the markup.

The two bar heights are declared once as CSS custom properties (`--ads-navh`, `--ads-tocbar`) because three rules depend on them — the bar's offset, the list's `max-height`, and the `scroll-margin-top` — and they have to move together.

## Verification

`npm run lint` clean, `npx tsc --noEmit` clean, `npm run build` succeeds including the prerender step; all 7 guide routes prerender.

Prerendered HTML ships `<details>` with **no `open` attribute**, so crawlers and no-JS readers get the collapsed state.

Measured in a headless browser at a 390x844 viewport, on a 12-heading article:

| | position |
|---|---|
| site header | 0 – 65 |
| article nav bar | 65 – 117 |
| heading jumped to from the menu | **131** (14px clear of both) |

Auto-close on link click confirmed (`details.open === false` after the click).

## Note

`/articles/*` routes do not prerender on `main` — `articles.tsx` is an empty collection and `entry-server.tsx:49` deliberately withholds those routes until it has entries. That is pre-existing and unchanged here; the measurements above come from a build with a test article spliced in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible table of contents to longer articles and guides.
  * Table of contents navigation is accessible and closes after selecting a link.
* **Bug Fixes**
  * Improved heading navigation so anchored sections account for sticky navigation bars.
  * Updated open table-of-contents lists to scroll within the available viewport.
* **Style**
  * Improved table-of-contents positioning and layout beneath site navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->