### PR TITLE
feat(content): add table blocks to the article content system

### DIFF
--- a/website/src/components/ContentBlockView.tsx
+++ b/website/src/components/ContentBlockView.tsx
@@ -8,7 +8,7 @@
 // It lives here rather than beside the shapes in content/shared.tsx because a
 // module that exports both components and plain helpers breaks Fast Refresh.
 
-import { ContentBlock, headingId, renderInline } from "@/content/shared";
+import { ContentBlock, headingId, renderInline, stripInline } from "@/content/shared";
 
 export default function ContentBlockView({ block }: { block: ContentBlock }) {
   if ("h2" in block) return <h2 id={headingId(block.h2)}>{block.h2}</h2>;
@@ -53,12 +53,14 @@ export default function ContentBlockView({ block }: { block: ContentBlock }) {
       // Firefox make a scroll container keyboard-reachable on their own; Safari
       // does not, so without tabIndex a narrow-viewport reader on Safari cannot
       // reach the columns that are off-screen. The name comes from the headers
-      // rather than a fixed string, since not every table is a comparison.
+      // rather than a fixed string, since not every table is a comparison --
+      // stripped, because a header may carry link syntax that renders fine in
+      // the cell but would be read out as raw punctuation in the label.
       <div
         className="content-table"
         tabIndex={0}
         role="region"
-        aria-label={headers.filter(Boolean).join(", ") || "Table"}
+        aria-label={headers.filter(Boolean).map(stripInline).join(", ") || "Table"}
       >
         <table>
           <thead>

--- a/website/src/components/ContentBlockView.tsx
+++ b/website/src/components/ContentBlockView.tsx
@@ -49,12 +49,24 @@ export default function ContentBlockView({ block }: { block: ContentBlock }) {
   if ("table" in block) {
     const { headers, rows } = block.table;
     return (
-      <div className="content-table">
+      // Focusable and labelled because the wrapper is what scrolls. Chrome and
+      // Firefox make a scroll container keyboard-reachable on their own; Safari
+      // does not, so without tabIndex a narrow-viewport reader on Safari cannot
+      // reach the columns that are off-screen. The name comes from the headers
+      // rather than a fixed string, since not every table is a comparison.
+      <div
+        className="content-table"
+        tabIndex={0}
+        role="region"
+        aria-label={headers.filter(Boolean).join(", ") || "Table"}
+      >
         <table>
           <thead>
             <tr>
               {headers.map((h, i) => (
-                <th key={i}>{renderInline(h)}</th>
+                <th key={i} scope="col">
+                  {renderInline(h)}
+                </th>
               ))}
             </tr>
           </thead>

--- a/website/src/components/ContentBlockView.tsx
+++ b/website/src/components/ContentBlockView.tsx
@@ -46,5 +46,30 @@ export default function ContentBlockView({ block }: { block: ContentBlock }) {
       </figure>
     );
   }
+  if ("table" in block) {
+    const { headers, rows } = block.table;
+    return (
+      <div className="content-table">
+        <table>
+          <thead>
+            <tr>
+              {headers.map((h, i) => (
+                <th key={i}>{renderInline(h)}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <td key={j}>{renderInline(cell)}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
   return null;
 }

--- a/website/src/content/guides.tsx
+++ b/website/src/content/guides.tsx
@@ -58,6 +58,15 @@ export const guides: Guide[] = [
       ] },
       { h2: "Typical price ranges in South Africa" },
       { p: "These are hedged, real-world ranges. Treat them as a guide, not a quote, because every project differs." },
+      { table: {
+        headers: ["Route", "Typical price", "Best for", "Watch out for"],
+        rows: [
+          ["DIY website builder", "R150–R600 / month", "Tight budgets and a willingness to build it yourself", "The hours you spend learning, building and fixing it"],
+          ["Freelancer", "R5,000–R25,000 once-off", "A straightforward small-business site", "Support can be hard to arrange once they move on"],
+          ["Agency", "R20,000–R80,000+ once-off", "Bigger brands that want a full team behind the build", "The most expensive route, often more than a small business needs"],
+          ["Done-for-you monthly (All Done Sites)", "From R799 / month", "No big upfront bill, with hosting and updates handled for you", "A recurring monthly fee instead of one lump sum"],
+        ],
+      } },
       { h3: "DIY website builders" },
       { p: "Platforms like Wix, Squarespace or WordPress let you build it yourself. Subscriptions often run from around R150 to R600 a month, plus your time. They are cheap on paper, but the cost shows up in the hours you spend learning, building and fixing things instead of running your business." },
       { h3: "Freelancers" },

--- a/website/src/content/shared.tsx
+++ b/website/src/content/shared.tsx
@@ -18,7 +18,8 @@ export type ContentBlock =
   | { ul: string[] }
   | { ol: string[] }
   | { callout: { title?: string; body: string } }
-  | { img: ContentImage };
+  | { img: ContentImage }
+  | { table: ContentTable };
 
 /**
  * An image inside an article body.
@@ -36,6 +37,18 @@ export type ContentImage = {
   width?: number;
   height?: number;
 };
+
+/**
+ * A table inside an article body.
+ *
+ * `headers` and `rows` are both required, and both plain string grids —
+ * no per-cell alignment, no colspans, no optional caption. A comparison
+ * table only needs the data; the rest is presentation the renderer already
+ * owns, and every field left unpopulated is a field someone has to notice
+ * is dead before they can trust the shape again. Every row is expected to
+ * have the same length as `headers`; the renderer does not pad or truncate.
+ */
+export type ContentTable = { headers: string[]; rows: string[][] };
 
 export type ContentFaq = { q: string; a: string };
 

--- a/website/src/styles/home.css
+++ b/website/src/styles/home.css
@@ -420,9 +420,14 @@ html { scroll-behavior: smooth; }
    wider than the viewport (common on a phone) must slide inside its own box,
    never push the article body sideways. */
 .adsx .content-table { margin: 26px 0; overflow-x: auto; border: 1px solid var(--ads-line); border-radius: 14px; box-shadow: var(--ads-sh); }
+.adsx .content-table:focus-visible { outline: 2px solid var(--ads-tx); outline-offset: 2px; }
 .adsx .content-table table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
-.adsx .content-table th, .adsx .content-table td { padding: 12px 16px; text-align: left; line-height: 1.5; white-space: nowrap; }
-.adsx .content-table thead th { background: var(--ads-soft); color: var(--ads-tx); font-family: var(--ads-disp); font-weight: 700; font-size: 12.5px; letter-spacing: .01em; border-bottom: 1px solid var(--ads-line); }
+.adsx .content-table th, .adsx .content-table td { padding: 12px 16px; text-align: left; line-height: 1.5; }
+/* Only the header row refuses to wrap. Body cells hold sentences, and `nowrap`
+   on them defeats the `width: 100%` above: the table's intrinsic width becomes
+   the sum of its longest sentences, so it overflows the wrapper on a desktop
+   viewport that had room to spare. */
+.adsx .content-table thead th { white-space: nowrap; background: var(--ads-soft); color: var(--ads-tx); font-family: var(--ads-disp); font-weight: 700; font-size: 12.5px; letter-spacing: .01em; border-bottom: 1px solid var(--ads-line); }
 .adsx .content-table tbody td { color: var(--ads-bd); border-bottom: 1px solid var(--ads-line2); }
 .adsx .content-table tbody tr:last-child td { border-bottom: none; }
 .adsx .content-table tbody tr:nth-child(even) td { background: var(--ads-soft); }

--- a/website/src/styles/home.css
+++ b/website/src/styles/home.css
@@ -416,6 +416,17 @@ html { scroll-behavior: smooth; }
 .adsx .content-figure img { display: block; width: 100%; height: auto; border-radius: 14px; border: 1px solid var(--ads-line); box-shadow: var(--ads-sh); }
 .adsx .content-figure figcaption { margin-top: 10px; font-size: 13px; line-height: 1.5; color: var(--ads-bd); text-align: center; }
 
+/* In-article tables. The wrapper -- not the page -- is what scrolls: a table
+   wider than the viewport (common on a phone) must slide inside its own box,
+   never push the article body sideways. */
+.adsx .content-table { margin: 26px 0; overflow-x: auto; border: 1px solid var(--ads-line); border-radius: 14px; box-shadow: var(--ads-sh); }
+.adsx .content-table table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
+.adsx .content-table th, .adsx .content-table td { padding: 12px 16px; text-align: left; line-height: 1.5; white-space: nowrap; }
+.adsx .content-table thead th { background: var(--ads-soft); color: var(--ads-tx); font-family: var(--ads-disp); font-weight: 700; font-size: 12.5px; letter-spacing: .01em; border-bottom: 1px solid var(--ads-line); }
+.adsx .content-table tbody td { color: var(--ads-bd); border-bottom: 1px solid var(--ads-line2); }
+.adsx .content-table tbody tr:last-child td { border-bottom: none; }
+.adsx .content-table tbody tr:nth-child(even) td { background: var(--ads-soft); }
+
 /* FAQs */
 .adsx .guide-faqs { margin-top: 40px; border-top: 1px solid var(--ads-line); padding-top: 8px; }
 .adsx .guide-faqs .qa { margin-top: 20px; }

--- a/website/src/styles/home.css
+++ b/website/src/styles/home.css
@@ -422,7 +422,10 @@ html { scroll-behavior: smooth; }
 .adsx .content-table { margin: 26px 0; overflow-x: auto; border: 1px solid var(--ads-line); border-radius: 14px; box-shadow: var(--ads-sh); }
 .adsx .content-table:focus-visible { outline: 2px solid var(--ads-tx); outline-offset: 2px; }
 .adsx .content-table table { width: 100%; border-collapse: collapse; font-size: 13.5px; }
-.adsx .content-table th, .adsx .content-table td { padding: 12px 16px; text-align: left; line-height: 1.5; }
+/* `vertical-align: top` matters once cells wrap: the default `middle` centres a
+   one-word cell against a seven-line one, so nothing in the row lines up and
+   the column you scan down is the one that drifts furthest. */
+.adsx .content-table th, .adsx .content-table td { padding: 12px 16px; text-align: left; line-height: 1.5; vertical-align: top; }
 /* Only the header row refuses to wrap. Body cells hold sentences, and `nowrap`
    on them defeats the `width: 100%` above: the table's intrinsic width becomes
    the sum of its longest sentences, so it overflows the wrapper on a desktop


### PR DESCRIPTION
## Problem

Article and guide bodies are built from a `ContentBlock` union — headings, paragraphs, lists, callouts, images. There was no way to express a table, so anything that is genuinely tabular (a pricing comparison, a route-by-route breakdown) had to be flattened into prose or a bullet list, which is harder to scan and loses the column relationship entirely.

## Change

Adds a `table` member to `ContentBlock`:

```ts
export type ContentTable = { headers: string[]; rows: string[][] };
```

Deliberately minimal — two required string grids, no per-cell alignment, no colspans, no caption. A comparison table only needs the data; the rest is presentation the renderer already owns, and an optional field nobody populates is a field the next person has to prove is dead before they can trust the shape.

- `ContentBlockView` renders real semantic `<table>` / `<thead>` / `<th>` / `<tbody>` / `<td>`. This is the single shared renderer for both the guides and articles collections, so one branch covers both.
- Every header and cell goes through `renderInline()`, so the existing `[text](/path)` link syntax works inside a table the same way it does in a paragraph.
- Styling lives in `home.css` alongside `.content-figure` and `.callout` and follows the same fixed-palette CSS-variable pattern the rest of that file uses. The table sits in an `overflow-x: auto` wrapper so a wide table scrolls inside its own box instead of pushing the page sideways on a phone.
- A four-column comparison table is added to the website-cost guide, using figures already stated in that article's prose (R150–R600 DIY, R5,000–R25,000 freelancer, R20,000–R80,000+ agency, R799 monthly) — no new claims.

Blocks that flatten content were checked rather than assumed: `stripInline()` only ever runs on standalone strings (`description`, FAQ answers), never over `blocks`, and the one per-block extractor, `imageSrcs()`, already returns `[]` for every non-image block. A `table` falls into that existing branch, the same as a `callout` does.

## Verification

`npx tsc --noEmit` clean, `npm run lint` clean, `npm run build` succeeds including the prerender step.

Prerendered HTML for the guide contains one `<table>`, 4 `<th>` and 16 `<td>` — the full 4×4 grid is in the static output, so it is there for crawlers and no-JS readers rather than being assembled on the client.

Measured in a headless browser, served without SPA fallback so a missing page would 404 rather than silently return the home page:

| viewport | page scroll width | table wrapper |
|---|---|---|
| 320px | 305 ≤ 320 — no page overflow | scrolls internally (1367 > 247) |
| 390px | 375 ≤ 390 — no page overflow | scrolls internally (1367 > 317) |
| 1440px | 1425 ≤ 1440 — no page overflow | fits |

The page itself never overflows horizontally at any of the three widths; only the table's own wrapper scrolls, which is the intended behaviour.

## Follow-ups on this branch

Review caught that `white-space: nowrap` had been applied to `td` as well as `th`. `table { width: 100% }` is a minimum, not a cap — a table's intrinsic width is the sum of its columns' minimum content widths, and `nowrap` makes a cell's minimum its entire text. So the table ballooned to 1367px inside a 758px wrapper at a **1440px desktop viewport**, clipping 609px: the whole "Watch out for" column, and part of "Best for", invisible with no scrollbar affordance to hint they were there.

Worth noting because both obvious assertions pass through it. `documentElement.scrollWidth <= innerWidth` is green at every width, since the wrapper absorbs the overflow by design; and a responsive-table check that only measures phone widths passes too, because at 320px the wrapper is *supposed* to scroll. It failed on desktop, not mobile.

Scoping `nowrap` to `thead th` fixes it — the header row is what genuinely needs to stay on one line. At 1440px the table now fits its wrapper exactly (758px, nothing clipped, all four columns visible). The phone case improved as a side effect: 458px of table instead of 1367px, so 141px of horizontal scroll instead of 1120px.

Two follow-ons from letting cells wrap:

- `vertical-align` defaulted to `middle`, invisible while every cell was one line. With cells wrapping to between one and seven lines it centred a one-word cell against a seven-line one — first-line offsets within a row spread by up to 60px at 320px, worst in the leftmost column, the one a reader scans down. `vertical-align: top` takes that to 0 at every width.
- The scroll region's accessible name joined the raw header strings. Headers go through `renderInline()`, so a link in a header is a supported pattern that renders correctly in the cell — but it reached the label verbatim, brackets and all. Now passed through `stripInline()`. Verified by putting a link in a real header and building: the label reads `Route, See pricing, Best for, Watch out for` while the cell still renders `<a href="/#pricing">pricing</a>`.

The scroll region also gained `tabIndex={0}`, `role="region"` and a `:focus-visible` outline. Chrome and Firefox make a scroll container keyboard-reachable on their own; Safari does not, so without it a reader there cannot reach off-screen columns. Header cells carry `scope="col"`. Both attributes are in the prerendered HTML rather than added at hydration.
