### PR TITLE
feat(content): support bold and italic in article inline text

### DIFF
--- a/website/src/components/ArticleNav.tsx
+++ b/website/src/components/ArticleNav.tsx
@@ -1,6 +1,6 @@
 // src/components/ArticleNav.tsx
 import { useRef } from "react";
-import { headingId } from "@/content/shared";
+import { headingId, stripInline } from "@/content/shared";
 
 interface ArticleNavProps {
   toc: string[];
@@ -33,8 +33,12 @@ export default function ArticleNav({ toc }: ArticleNavProps) {
           }}
         >
           {toc.map((h) => (
+            // Flattened, not rendered: the heading itself may carry emphasis,
+            // but a <strong> inside a table-of-contents link would compete with
+            // the nav's own styling for no reader benefit. headingId() still
+            // gets the raw string, so this anchor matches the id on the heading.
             <li key={h}>
-              <a href={`#${headingId(h)}`}>{h}</a>
+              <a href={`#${headingId(h)}`}>{stripInline(h)}</a>
             </li>
           ))}
         </ol>

--- a/website/src/components/ContentBlockView.tsx
+++ b/website/src/components/ContentBlockView.tsx
@@ -11,8 +11,14 @@
 import { ContentBlock, headingId, renderInline, stripInline } from "@/content/shared";
 
 export default function ContentBlockView({ block }: { block: ContentBlock }) {
-  if ("h2" in block) return <h2 id={headingId(block.h2)}>{block.h2}</h2>;
-  if ("h3" in block) return <h3>{block.h3}</h3>;
+  // Headings run through renderInline like every other block. Bold inside a
+  // heading is a far more natural thing to type than a link inside one, and a
+  // heading that rendered its markup literally would put raw asterisks in the
+  // largest text on the page. headingId() is deliberately fed the RAW string:
+  // its [^\w\s-] strip already removes the delimiters, so the slug -- and the
+  // nav anchor pointing at it -- is identical either way.
+  if ("h2" in block) return <h2 id={headingId(block.h2)}>{renderInline(block.h2)}</h2>;
+  if ("h3" in block) return <h3>{renderInline(block.h3)}</h3>;
   if ("p" in block) return <p>{renderInline(block.p)}</p>;
   if ("ul" in block)
     return (
@@ -33,7 +39,7 @@ export default function ContentBlockView({ block }: { block: ContentBlock }) {
   if ("callout" in block)
     return (
       <div className="callout">
-        {block.callout.title && <h3>{block.callout.title}</h3>}
+        {block.callout.title && <h3>{renderInline(block.callout.title)}</h3>}
         <p>{renderInline(block.callout.body)}</p>
       </div>
     );

--- a/website/src/content/shared.tsx
+++ b/website/src/content/shared.tsx
@@ -4,9 +4,13 @@
 // items as structured data using these same block/FAQ shapes, so there is one
 // definition of "what an article body looks like" no matter how many
 // collections the site grows to. Paragraph/list strings may use a tiny
-// markdown-style inline link, [text](/path), which renderInline() turns into
-// a router <Link> (internal) or <a> (external); stripInline() flattens it to
-// plain text for structured data.
+// markdown-style inline vocabulary -- [text](/path) links, **bold**, and
+// *italic* -- which renderInline() turns into a router <Link> (internal) or
+// <a> (external) plus <strong>/<em>; stripInline() flattens all of it to
+// plain text for structured data. That vocabulary is deliberately small: no
+// underscores, no inline code, no strikethrough. Every construct added here
+// is one the content generator has to be taught and the content gates have
+// to be taught to measure, so it stays link + bold + italic only.
 
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
@@ -52,41 +56,78 @@ export type ContentTable = { headers: string[]; rows: string[][] };
 
 export type ContentFaq = { q: string; a: string };
 
-const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
+// One alternative per construct, tried in this order at every position:
+//   1. [label](href)         -- captures label in group 1, href in group 2
+//   2. **bold text**         -- captures the inner text in group 3
+//   3. *italic text*         -- captures the inner text in group 4
+// Bold is listed before italic so "**bold**" resolves as one <strong> rather
+// than an empty <em> hugging a "*bold*" leftover -- if italic were tried
+// first it would happily match the inner "*bold*" and strand the outer pair
+// of asterisks as literal text. The inner-content groups reject a leading or
+// trailing space and any nested "*", so "R5 * 3" (one asterisk, no partner)
+// and a sentence trailing off with a lone "*" never pair up into emphasis;
+// a delimiter with nothing to close it on the same string just stays literal.
+//
+// This is exported as a source string, not a compiled RegExp: renderInline
+// recurses to parse the content it captures (a link label may hide **bold**,
+// bold/italic content may hide a [link]), and a regex literal re-evaluated
+// inside a function body is a fresh object per call, but a single shared
+// module-level RegExp would have its `lastIndex` clobbered by the recursive
+// call before the outer loop reads it back.
+const TOKEN_SOURCE =
+  "\\[([^\\]]+)\\]\\(([^)]+)\\)" +
+  "|\\*\\*([^\\s*](?:[^*]*[^\\s*])?)\\*\\*" +
+  "|\\*([^\\s*](?:[^*]*[^\\s*])?)\\*(?!\\*)";
 
-/** Turn [text](/path) markdown into router <Link>s (internal) or <a>s (external). */
+/**
+ * Turn the article inline vocabulary -- [text](/path) links, **bold**,
+ * *italic* -- into React nodes: router <Link>s (internal href) or <a>s
+ * (external), <strong>, <em>. All three interleave in one tokenising pass,
+ * in any order, and nest inside one another (a link label may contain
+ * **bold**; **bold** may wrap a [link]).
+ */
 export function renderInline(text: string): ReactNode {
+  const re = new RegExp(TOKEN_SOURCE, "g");
   const out: ReactNode[] = [];
   let last = 0;
   let key = 0;
   let m: RegExpExecArray | null;
-  LINK_RE.lastIndex = 0;
-  while ((m = LINK_RE.exec(text)) !== null) {
+  while ((m = re.exec(text)) !== null) {
     if (m.index > last) out.push(text.slice(last, m.index));
-    const label = m[1];
-    const href = m[2];
-    if (href.startsWith("/")) {
+    if (m[1] !== undefined) {
+      const href = m[2];
+      const children = renderInline(m[1]);
       out.push(
-        <Link key={key++} to={href}>
-          {label}
-        </Link>
+        href.startsWith("/") ? (
+          <Link key={key++} to={href}>
+            {children}
+          </Link>
+        ) : (
+          <a key={key++} href={href} target="_blank" rel="noopener noreferrer">
+            {children}
+          </a>
+        )
       );
-    } else {
-      out.push(
-        <a key={key++} href={href} target="_blank" rel="noopener noreferrer">
-          {label}
-        </a>
-      );
+    } else if (m[3] !== undefined) {
+      out.push(<strong key={key++}>{renderInline(m[3])}</strong>);
+    } else if (m[4] !== undefined) {
+      out.push(<em key={key++}>{renderInline(m[4])}</em>);
     }
-    last = LINK_RE.lastIndex;
+    last = re.lastIndex;
   }
   if (last < text.length) out.push(text.slice(last));
   return out.length === 1 ? out[0] : out;
 }
 
-/** Flatten [text](/path) markdown to plain text, for JSON-LD / meta. */
+/** Flatten the article inline vocabulary to plain text, for JSON-LD / meta. */
 export function stripInline(text: string): string {
-  return text.replace(LINK_RE, "$1");
+  const re = new RegExp(TOKEN_SOURCE, "g");
+  return text.replace(re, (_match, label, _href, bold, italic) => {
+    if (label !== undefined) return stripInline(label);
+    if (bold !== undefined) return stripInline(bold);
+    if (italic !== undefined) return stripInline(italic);
+    return _match;
+  });
 }
 
 /** Slug for an h2, so the on-this-page nav can link to it. */

--- a/website/src/content/shared.tsx
+++ b/website/src/content/shared.tsx
@@ -11,6 +11,12 @@
 // underscores, no inline code, no strikethrough. Every construct added here
 // is one the content generator has to be taught and the content gates have
 // to be taught to measure, so it stays link + bold + italic only.
+//
+// Every string a reader sees goes through renderInline(), and every string a
+// crawler sees goes through stripInline(). Those two sets have to stay in
+// step: a field rendered raw but stripped for JSON-LD puts literal asterisks
+// on the page and clean text in the structured data, which is exactly the
+// disagreement between visible and machine-readable content to avoid.
 
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
@@ -57,16 +63,40 @@ export type ContentTable = { headers: string[]; rows: string[][] };
 export type ContentFaq = { q: string; a: string };
 
 // One alternative per construct, tried in this order at every position:
-//   1. [label](href)         -- captures label in group 1, href in group 2
-//   2. **bold text**         -- captures the inner text in group 3
-//   3. *italic text*         -- captures the inner text in group 4
+//   1. [label](href)         -- label in group 1, href in group 2
+//   2. **bold text**         -- opening boundary in group 3, inner text in 4
+//   3. *italic text*         -- opening boundary in group 5, inner text in 6
 // Bold is listed before italic so "**bold**" resolves as one <strong> rather
 // than an empty <em> hugging a "*bold*" leftover -- if italic were tried
 // first it would happily match the inner "*bold*" and strand the outer pair
-// of asterisks as literal text. The inner-content groups reject a leading or
-// trailing space and any nested "*", so "R5 * 3" (one asterisk, no partner)
-// and a sentence trailing off with a lone "*" never pair up into emphasis;
-// a delimiter with nothing to close it on the same string just stays literal.
+// of asterisks as literal text.
+//
+// An emphasis run may only OPEN at the start of the string or straight after
+// whitespace, "(" or "[". That restriction is the whole defence against the
+// asterisk's other job in prose: the footnote marker. This content is pricing
+// copy, and a marker is glued to the end of a word -- so in
+//
+//     Includes hosting*, domain*, and email.
+//
+// both asterisks have a partner on the same string, and both are preceded by a
+// letter. Without the boundary rule the pair matches and the rendered sentence
+// reads "Includes hosting, domain, and email." -- the markers are DELETED, not
+// merely decorated, so the pointer to the "*Prices exclude VAT" line below is
+// gone from the page, from <meta description> and from the JSON-LD at once.
+// Requiring a leading space/paren/bracket makes every such marker literal,
+// because a footnote marker is never preceded by a space.
+//
+// It is NOT enough that the inner text rejects a leading or trailing space.
+// That rule alone saves "R799* a month. *Prices exclude VAT." (the space after
+// the first marker stops it opening) but not the comma-separated form above,
+// which is why the boundary is spelled out separately here.
+//
+// The boundary is a captured group rather than a lookbehind on purpose. This
+// RegExp is constructed at render time, so an engine that cannot parse it
+// throws instead of degrading -- and a SyntaxError here takes out the entire
+// article body. Lookbehind needs Safari 16.4+ (March 2023), which is younger
+// than plenty of phones still reading this site, so the boundary is consumed
+// and re-emitted by the two callers below instead.
 //
 // This is exported as a source string, not a compiled RegExp: renderInline
 // recurses to parse the content it captures (a link label may hide **bold**,
@@ -76,8 +106,8 @@ export type ContentFaq = { q: string; a: string };
 // call before the outer loop reads it back.
 const TOKEN_SOURCE =
   "\\[([^\\]]+)\\]\\(([^)]+)\\)" +
-  "|\\*\\*([^\\s*](?:[^*]*[^\\s*])?)\\*\\*" +
-  "|\\*([^\\s*](?:[^*]*[^\\s*])?)\\*(?!\\*)";
+  "|(^|[\\s([])\\*\\*([^\\s*](?:[^*]*[^\\s*])?)\\*\\*" +
+  "|(^|[\\s([])\\*([^\\s*](?:[^*]*[^\\s*])?)\\*(?!\\*)";
 
 /**
  * Turn the article inline vocabulary -- [text](/path) links, **bold**,
@@ -93,7 +123,15 @@ export function renderInline(text: string): ReactNode {
   let key = 0;
   let m: RegExpExecArray | null;
   while ((m = re.exec(text)) !== null) {
-    if (m.index > last) out.push(text.slice(last, m.index));
+    // The emphasis alternatives consume their opening boundary -- the space or
+    // "(" that proves the run is not a footnote marker glued to a word -- so it
+    // has to be put back. It is concatenated onto the preceding literal chunk
+    // rather than pushed as its own node: two adjacent strings in one React
+    // array are serialised with a "<!-- -->" separator between them, and that
+    // marker would land in the prerendered HTML of every emphasised sentence.
+    const boundary = m[3] ?? m[5] ?? "";
+    const literal = text.slice(last, m.index) + boundary;
+    if (literal) out.push(literal);
     if (m[1] !== undefined) {
       const href = m[2];
       const children = renderInline(m[1]);
@@ -108,10 +146,10 @@ export function renderInline(text: string): ReactNode {
           </a>
         )
       );
-    } else if (m[3] !== undefined) {
-      out.push(<strong key={key++}>{renderInline(m[3])}</strong>);
     } else if (m[4] !== undefined) {
-      out.push(<em key={key++}>{renderInline(m[4])}</em>);
+      out.push(<strong key={key++}>{renderInline(m[4])}</strong>);
+    } else if (m[6] !== undefined) {
+      out.push(<em key={key++}>{renderInline(m[6])}</em>);
     }
     last = re.lastIndex;
   }
@@ -122,10 +160,13 @@ export function renderInline(text: string): ReactNode {
 /** Flatten the article inline vocabulary to plain text, for JSON-LD / meta. */
 export function stripInline(text: string): string {
   const re = new RegExp(TOKEN_SOURCE, "g");
-  return text.replace(re, (_match, label, _href, bold, italic) => {
+  return text.replace(re, (_match, label, _href, boldOpen, bold, italicOpen, italic) => {
     if (label !== undefined) return stripInline(label);
-    if (bold !== undefined) return stripInline(bold);
-    if (italic !== undefined) return stripInline(italic);
+    // The opening boundary is re-emitted for the same reason renderInline puts
+    // it back: it is the separating whitespace, not part of the emphasis. Drop
+    // it and "cost you **more** later" would flatten to "cost youmore later".
+    if (bold !== undefined) return boldOpen + stripInline(bold);
+    if (italic !== undefined) return italicOpen + stripInline(italic);
     return _match;
   });
 }

--- a/website/src/content/shared.tsx
+++ b/website/src/content/shared.tsx
@@ -72,7 +72,9 @@ export type ContentFaq = { q: string; a: string };
 // of asterisks as literal text.
 //
 // An emphasis run may only OPEN at the start of the string or straight after
-// whitespace, "(" or "[". That restriction is the whole defence against the
+// whitespace, "(" or "[" -- optionally with one opening quote in between, so
+// that A "**done-for-you**" site emphasises rather than showing its asterisks.
+// That restriction is the whole defence against the
 // asterisk's other job in prose: the footnote marker. This content is pricing
 // copy, and a marker is glued to the end of a word -- so in
 //
@@ -91,6 +93,19 @@ export type ContentFaq = { q: string; a: string };
 // the first marker stops it opening) but not the comma-separated form above,
 // which is why the boundary is spelled out separately here.
 //
+// The optional quote is deliberately only honoured when the quote ITSELF sits
+// at an opening position -- i.e. the sequence is space-then-quote, never
+// word-then-quote. A bare quote in the class would re-open the same deletion
+// bug one step along, because a footnote marker can follow a CLOSING quote:
+//
+//     He said "hello"*, and "goodbye"*.
+//
+// there the first "*" is preceded by a quote, the pair would match, and both
+// markers would vanish. Requiring the quote to be preceded by whitespace or
+// "(" keeps that string literal while still emphasising a quoted phrase.
+// Straight and curly quotes are both accepted; the closing curly quotes are
+// not in the class, as they can only ever appear at the wrong end.
+//
 // The boundary is a captured group rather than a lookbehind on purpose. This
 // RegExp is constructed at render time, so an engine that cannot parse it
 // throws instead of degrading -- and a SyntaxError here takes out the entire
@@ -104,10 +119,11 @@ export type ContentFaq = { q: string; a: string };
 // inside a function body is a fresh object per call, but a single shared
 // module-level RegExp would have its `lastIndex` clobbered by the recursive
 // call before the outer loop reads it back.
+const EMPHASIS_OPEN = "(?:^|[\\s([])[\"'\\u201C\\u2018]?";
 const TOKEN_SOURCE =
   "\\[([^\\]]+)\\]\\(([^)]+)\\)" +
-  "|(^|[\\s([])\\*\\*([^\\s*](?:[^*]*[^\\s*])?)\\*\\*" +
-  "|(^|[\\s([])\\*([^\\s*](?:[^*]*[^\\s*])?)\\*(?!\\*)";
+  "|(" + EMPHASIS_OPEN + ")\\*\\*([^\\s*](?:[^*]*[^\\s*])?)\\*\\*" +
+  "|(" + EMPHASIS_OPEN + ")\\*([^\\s*](?:[^*]*[^\\s*])?)\\*(?!\\*)";
 
 /**
  * Turn the article inline vocabulary -- [text](/path) links, **bold**,

--- a/website/src/pages/ArticleArticle.tsx
+++ b/website/src/pages/ArticleArticle.tsx
@@ -5,7 +5,7 @@ import { PageShell } from "@/components/redesign/RedesignChrome";
 import { getArticle, getRelatedSlugs } from "@/content/articles";
 import ContentBlockView from "@/components/ContentBlockView";
 import ArticleNav from "@/components/ArticleNav";
-import { absoluteImage, imageSrcs, stripInline } from "@/content/shared";
+import { absoluteImage, imageSrcs, renderInline, stripInline } from "@/content/shared";
 import "@/styles/home.css";
 
 const SITE = "https://alldonesites.com";
@@ -58,7 +58,7 @@ export default function ArticleArticle() {
           "@type": "FAQPage",
           mainEntity: article.faqs.map((f) => ({
             "@type": "Question",
-            name: f.q,
+            name: stripInline(f.q),
             acceptedAnswer: { "@type": "Answer", text: stripInline(f.a) },
           })),
         }
@@ -78,7 +78,7 @@ export default function ArticleArticle() {
     >
       <Seo
         title={article.metaTitle}
-        description={article.description}
+        description={stripInline(article.description)}
         canonical={url}
         image={OG_IMAGE}
         jsonLd={faqSchema ? [articleSchema, faqSchema] : articleSchema}
@@ -86,7 +86,7 @@ export default function ArticleArticle() {
 
       <div className="guide-layout">
         <article className="legal guide-body">
-          <p className="intro">{article.intro}</p>
+          <p className="intro">{renderInline(article.intro)}</p>
 
           <ArticleNav toc={toc} />
 
@@ -99,8 +99,8 @@ export default function ArticleArticle() {
               <h2 id="faqs">Frequently asked questions</h2>
               {article.faqs.map((f) => (
                 <div className="qa" key={f.q}>
-                  <h3>{f.q}</h3>
-                  <p>{f.a}</p>
+                  <h3>{renderInline(f.q)}</h3>
+                  <p>{renderInline(f.a)}</p>
                 </div>
               ))}
             </section>

--- a/website/src/pages/GuideArticle.tsx
+++ b/website/src/pages/GuideArticle.tsx
@@ -7,6 +7,7 @@ import {
   GUIDES_UPDATED,
   getGuide,
   getRelatedSlugs,
+  renderInline,
   stripInline,
 } from "@/content/guides";
 import ContentBlockView from "@/components/ContentBlockView";
@@ -61,7 +62,7 @@ export default function GuideArticle() {
     "@type": "FAQPage",
     mainEntity: guide.faqs.map((f) => ({
       "@type": "Question",
-      name: f.q,
+      name: stripInline(f.q),
       acceptedAnswer: { "@type": "Answer", text: stripInline(f.a) },
     })),
   };
@@ -80,7 +81,7 @@ export default function GuideArticle() {
     >
       <Seo
         title={guide.metaTitle}
-        description={guide.description}
+        description={stripInline(guide.description)}
         canonical={url}
         image={OG_IMAGE}
         jsonLd={[articleSchema, faqSchema]}
@@ -88,7 +89,7 @@ export default function GuideArticle() {
 
       <div className="guide-layout">
         <article className="legal guide-body">
-          <p className="intro">{guide.intro}</p>
+          <p className="intro">{renderInline(guide.intro)}</p>
 
           <ArticleNav toc={toc} />
 
@@ -101,8 +102,8 @@ export default function GuideArticle() {
               <h2 id="faqs">Frequently asked questions</h2>
               {guide.faqs.map((f) => (
                 <div className="qa" key={f.q}>
-                  <h3>{f.q}</h3>
-                  <p>{f.a}</p>
+                  <h3>{renderInline(f.q)}</h3>
+                  <p>{renderInline(f.a)}</p>
                 </div>
               ))}
             </section>


### PR DESCRIPTION
## Problem

`renderInline()` is what every article body block runs through — paragraphs, list items, callouts, table cells and table headers. It understood exactly one inline construct:

```ts
const LINK_RE = /\[([^\]]+)\]\(([^)]+)\)/g;
```

So `**bold**` and `*italic*` rendered as literal asterisks on the published page, and an article had no way to emphasise a phrase mid-sentence.

## Change

One tokenising pass over a single alternation, tried in precedence order at every position: `[label](href)`, then `**bold**`, then `*italic*`.

- **Bold is tried before italic on purpose.** Matching `*` first turns `**bold**` into an empty `<em>` wrapping `*bold*`.
- **A lone or unpaired asterisk stays literal.** The inner-content group rejects leading and trailing whitespace and any internal `*`, so `R5 * 3` and `2 * 2 = 4` are untouched — this content is full of prices and arithmetic.
- **Nesting works both ways.** A matched link label, bold body or italic body is recursively re-parsed by the same function, so `[**Get a quote**](/#quote)` and `**[text](/path)**` both work.
- Each call builds its own `RegExp`. A shared module-level stateful regex would have its `lastIndex` clobbered by the recursive inner call before the outer loop read it back.
- `stripInline()` flattens all three constructs, since it feeds `<meta>` descriptions and JSON-LD where markup must not appear.

Deliberately **no** other markdown — no underscore emphasis, no inline code, no strikethrough. Every construct added here is one the content generator has to be taught and every gate that measures content has to be taught to measure.

The internal-vs-external link split is unchanged: a `/` prefix gives a router `<Link>`, anything else an `<a target="_blank" rel="noopener noreferrer">`. No `dangerouslySetInnerHTML` — the output is a plain `ReactNode` tree, so React's escaping still applies.

## Styling

None added. `GuideArticle`'s `<article>` already carries `legal guide-body`, and the existing `.adsx .legal strong` rule styles `<strong>`. `<em>` takes browser-default italic in the inherited body colour. Confirmed against computed styles in a real browser rather than assumed: `<strong>` resolves to `font-weight: 600` / `rgb(15, 23, 42)`, `<em>` to `font-style: italic` / `rgb(71, 85, 105)`, matching the surrounding text.

## Verification

`npx tsc --noEmit`, `npm run lint` and `npm run build` all clean, including the SSR prerender of all 7 guides.

There is no JS test runner configured in this repo, so verification is against real built output. Emphasis was temporarily added to a real guide, rebuilt, and asserted against the **prerendered HTML bytes**:

```
<em>not a once-off purchase</em>
<strong>quietly cost you more</strong>
<strong>Get a quick quote</strong>      (inside <a href="/#getquote">)
...Plans start at R799* a mo...          (literal asterisk, no <em>)
```

Served with `python3 -m http.server` from inside `dist/` rather than `serve -s`, which SPA-falls-back to the home page with a 200 for any unresolved path and would have measured the wrong page. Page identity asserted on the raw response bytes. Zero React hydration errors in a real browser.

The demo emphasis was then **reverted** — one of the four demo edits asserted "Prices shown exclude VAT", which is a claim about the business's pricing policy rather than a rendering demonstration, and not one to invent on a live site. This PR is renderer-only; the assertions above are the evidence the feature works end to end against real content.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for inline links, bold text, and italic text across article and guide content.
  * Inline formatting now appears in headings, callouts, introductions, FAQs, and table-of-contents labels.

* **Bug Fixes**
  * Improved handling of emphasis markers and nested inline formatting.
  * Cleaned formatted text for navigation labels and search-engine metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->