### PR TITLE
docs(content): correct two false claims in the emphasis comments

### DIFF
--- a/website/src/components/ContentBlockView.tsx
+++ b/website/src/components/ContentBlockView.tsx
@@ -14,9 +14,16 @@ export default function ContentBlockView({ block }: { block: ContentBlock }) {
   // Headings run through renderInline like every other block. Bold inside a
   // heading is a far more natural thing to type than a link inside one, and a
   // heading that rendered its markup literally would put raw asterisks in the
-  // largest text on the page. headingId() is deliberately fed the RAW string:
-  // its [^\w\s-] strip already removes the delimiters, so the slug -- and the
-  // nav anchor pointing at it -- is identical either way.
+  // largest text on the page. headingId() is deliberately fed the RAW string,
+  // and ArticleNav must feed it the RAW string too, or the anchors stop
+  // matching. For emphasis the two are interchangeable -- [^\w\s-] removes the
+  // delimiters either way. ⚠ For a LINK they are not: [^\w\s-] strips the
+  // brackets but leaves the href in the slug, so
+  //   headingId("See [pricing](/pricing) now")             -> see-pricingpricing-now
+  //   headingId(stripInline("See [pricing](/pricing) now")) -> see-pricing-now
+  // Both call sites currently pass raw, so they agree and every published
+  // anchor is stable. Switching only one of them would silently break the nav
+  // on any heading containing a link.
   if ("h2" in block) return <h2 id={headingId(block.h2)}>{renderInline(block.h2)}</h2>;
   if ("h3" in block) return <h3>{renderInline(block.h3)}</h3>;
   if ("p" in block) return <p>{renderInline(block.p)}</p>;

--- a/website/src/content/shared.tsx
+++ b/website/src/content/shared.tsx
@@ -17,6 +17,14 @@
 // step: a field rendered raw but stripped for JSON-LD puts literal asterisks
 // on the page and clean text in the structured data, which is exactly the
 // disagreement between visible and machine-readable content to avoid.
+//
+// ⚠ `title`, `metaTitle` and `summary` are OUTSIDE the vocabulary -- they are
+// plain text, passed raw to every consumer. That is consistent today, so there
+// is no divergence, but they are the next fields a content generator reaches
+// for: `title` alone is displayed in the <h1> AND emitted as Article.headline
+// and ItemList.name, so the day one of them carries a `**` the asterisks show
+// up in the largest text on the page and in the structured data at once. Add
+// them to renderInline/stripInline before allowing markup in them, never after.
 
 import { ReactNode } from "react";
 import { Link } from "react-router-dom";
@@ -85,8 +93,25 @@ export type ContentFaq = { q: string; a: string };
 // reads "Includes hosting, domain, and email." -- the markers are DELETED, not
 // merely decorated, so the pointer to the "*Prices exclude VAT" line below is
 // gone from the page, from <meta description> and from the JSON-LD at once.
-// Requiring a leading space/paren/bracket makes every such marker literal,
-// because a footnote marker is never preceded by a space.
+// Requiring a leading space/paren/bracket makes every WORD-GLUED marker
+// literal, because a marker attached to the end of a word is never preceded by
+// a space.
+//
+// ⚠ That is the exact guarantee, and it is narrower than "footnote markers are
+// safe". A marker at the START of a sentence -- the disclaimer's own marker --
+// IS preceded by a space, so it can still open a run and pair with a later
+// word-glued one. Confirmed:
+//
+//     "*Prices exclude VAT. Plans start at R799*."
+//        -> "Prices exclude VAT. Plans start at R799."
+//
+// Both markers deleted, in the render and the strip alike. The reverse order,
+// "Plans start at R799* a month. *Prices exclude VAT.", is safe -- so it is
+// disclaimer-FIRST, in the same string, that collapses. No boundary rule can
+// reject this without also rejecting a legitimate sentence-initial *italic*,
+// and CommonMark resolves it the same way, so it is inherent ambiguity rather
+// than a defect here. Keep a disclaimer sentence in its own string, or out of
+// a string that also carries a glued marker.
 //
 // It is NOT enough that the inner text rejects a leading or trailing space.
 // That rule alone saves "R799* a month. *Prices exclude VAT." (the space after


### PR DESCRIPTION
Follow-up to #29, closing the three non-blocking findings its review raised. **Comments only** — no executable change.

## What was wrong

**1. The boundary comment stated a false universal.** It claimed *"a footnote marker is never preceded by a space"*, and used that to conclude every footnote marker is safe. A disclaimer's own marker sits at the start of a sentence, so it *is* preceded by a space and can open a run:

```
"*Prices exclude VAT. Plans start at R799*."  ->  "Prices exclude VAT. Plans start at R799."
```

Both markers deleted, in `renderInline` and `stripInline` alike. The reverse order (`"Plans start at R799* a month. *Prices exclude VAT."`) is safe — so it is disclaimer-**first**, in the same string, that collapses.

This is not a fixable defect: no boundary rule rejects it without also rejecting a legitimate sentence-initial `*italic*`, and CommonMark resolves the same string the same way. So the comment now states the guarantee that is actually enforced — *word-glued* markers are literal — rather than one a maintainer would ship a collapse trusting.

**2. `ContentBlockView` claimed the heading slug is "identical either way".** True for emphasis, false for a link — `[^\w\s-]` strips the brackets but leaves the href in the slug:

```
headingId("See [pricing](/pricing) now")               ->  see-pricingpricing-now
headingId(stripInline("See [pricing](/pricing) now"))  ->  see-pricing-now
```

Both call sites pass raw today and therefore agree, so no published anchor is affected. The problem was that the comment *sanctioned* feeding one side the stripped string, which would silently break the nav anchor on any heading containing a link.

**3. `title` / `metaTitle` / `summary` are outside the vocabulary** and passed raw to every consumer. Consistent today, but `title` is displayed in the `<h1>` *and* emitted as `Article.headline` and `ItemList.name`, so markup arriving in it would put literal asterisks in the largest text on the page and in the structured data simultaneously. Now recorded next to the vocabulary comment.

## Verification

Every claim written into the comments was executed against the real exported functions, not asserted from reading:

| Claim | Result |
|---|---|
| disclaimer-first collapses (render + strip) | confirmed |
| disclaimer-last stays literal (render + strip) | confirmed |
| `headingId(raw)` keeps the href in the slug | confirmed |
| `headingId(stripped)` does not | confirmed |
| emphasis slug identical either way | confirmed |

And because it is comments only, the build proves it: **all 14 prerendered pages byte-identical** to the merged `main` build, and the **CSS byte-identical** too (so no stray Tailwind utility from a token appearing in comment prose). `eslint` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified heading anchor behavior to keep navigation consistent, including headings containing links.
  * Documented that titles, metadata titles, and summaries use plain text and should not include inline markup.
  * Expanded guidance on emphasis boundaries and noted an existing ambiguity in sentence-initial formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->